### PR TITLE
fix: to_path, rebuild logic of path and methods that associated with it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Joins two paths together. The behavior depends on the type of the second.
 #### Examples
 
 ```moonbit
-let unix1 = UnixPath({ path: to_path(["home", "user"]) })
-let unix2 = UnixPath({ path: to_path(["documents", "file.txt"]) })
-let win = WinPath({ disk: 'C', path: to_path(["Users", "file.txt"]) })
+let unix1 = UnixPath({ path: to_path(["/home", "user"]) })
+let unix2 = UnixPath({ path: to_path(["/documents", "file.txt"]) })
+let win = WinPath({ disk: 'C', path: to_path(["\\Users", "file.txt"]) })
 unix_path(unix1.join(unix2)) |> println // /home/user/documents/file.txt
 win_path(unix1.join(win)) |> println // C:\Users\file.txt
 ```
@@ -88,10 +88,10 @@ Returns the parent directory component of the path.
 
 #### Examples
 ```moonbit
-let unix_path = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
+let unix_path = UnixPath({ path: to_path(["/home", "user", "file.txt"]) })
 let win_path = WinPath({
   disk: 'C',
-  path: to_path(["Users", "Documents", "file.txt"]),
+  path: to_path(["\\Users", "Documents", "file.txt"]),
 })
 unix_path.parent() |> println // /home/user
 win_path.parent() |> println // C:\Users\Documents
@@ -103,9 +103,19 @@ Converts an array of strings into a `PurePath` type by joining the strings in re
 
 #### Examples
 ```moonbit
-let components = ["usr", "local", "bin"]
+let components = ["/usr", "local", "bin"]
 let path = to_path(components)
 unix_path(UnixPath({ path })) |> println // /usr/local/bin
+```
+
+Spurious slashes and single dots are collapsed, but double dots ('..') and leading double slashes ('//') are not.
+
+```moonbit
+test "to_path" {
+  let components = ["/usr", "local/bin", "./test/../path", "t.py"]
+  let path = to_path(components)
+  println(UnixPath({path}).unix_path())// /usr/local/bin/test/../path/t.py
+}
 ```
 
 ### pub fn Path::unix_path(self : Path) -> String
@@ -114,7 +124,7 @@ Converts a path to its Unix representation.
 
 #### Examples
 ```moonbit
-let path = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
+let path = UnixPath({ path: to_path(["/home", "user", "file.txt"]) })
 unix_path(path) |> println // /home/user/file.txt
 ```
 
@@ -124,7 +134,7 @@ Converts a path to its Windows representation.
 
 #### Examples
 ```moonbit
-let win_path = WinPath({ disk: 'C', path: to_path(["Users", "Documents"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["\\Users", "Documents"]) })
 win_path(win_path) |> println // C:\Users\Documents
 ```
 
@@ -135,8 +145,8 @@ Provide win_path and unix_path to string.
 #### Examples
 
 ```moonbit
-let winpath = WinPath({ disk: 'C', path: to_path(["Users", "Documents"]) })
-let unixpath = UnixPath({ path: to_path(["user", "local"]) })
+let winpath = WinPath({ disk: 'C', path: to_path(["\\Users", "Documents"]) })
+let unixpath = UnixPath({ path: to_path(["/user", "local"]) })
 println(winpath.to_string()) // C:\Users\Documents
 println(unixpath.to_string()) // /user/local
 ```
@@ -148,12 +158,12 @@ Creates a Path instance from a string representation of a file system path.
 #### Examples
 ```moonbit
 test "path" {
-// Unix-style paths
-path!("/usr/local/bin").to_string() |> println // /usr/local/bin
-// Windows-style paths
-path!("C:\\Windows\\System32").to_string() |> println // C:\Windows\System32
-// Single component becomes Unix path
-path!("file.txt").to_string() |> println // file.txt
+  // Unix-style paths
+  path!("/usr/local/bin").to_string() |> println // /usr/local/bin
+  // Windows-style paths
+  path!("C:\\Windows\\System32").to_string() |> println // C:\Windows\System32
+  // Single component becomes Unix path
+  path!("file.txt").to_string() |> println // file.txt
 }
 ```
 
@@ -163,8 +173,8 @@ Returns the file name component of the path.
 
 #### Examples
 ```moonbit
-let unix_path = UnixPath({ path: to_path(["home", "user", "document.txt"]) })
-let win_path = WinPath({ disk: 'C', path: to_path(["Users", "file.pdf"]) })
+let unix_path = UnixPath({ path: to_path(["/home", "user", "document.txt"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["\\Users", "file.pdf"]) })
 unix_path.file_name() |> println // document.txt
 win_path.file_name() |> println // file.pdf
 ```
@@ -175,8 +185,8 @@ Returns the file stem (name without extension) of the path.
 
 #### Examples
 ```moonbit
-let unix_path = UnixPath({ path: to_path(["home", "user", "document.txt"]) })
-let win_path = WinPath({ disk: 'C', path: to_path(["Users", "file.tar.gz"]) })
+let unix_path = UnixPath({ path: to_path(["/home", "user", "document.txt"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["\\Users", "file.tar.gz"]) })
 unix_path.file_stem() |> println // document
 win_path.file_stem() |> println // file
 ```
@@ -187,8 +197,8 @@ Returns the prefix of the file name in a path, including all except the last ext
 
 #### Examples
 ```moonbit
-let win_path = WinPath({ disk: 'C', path: to_path(["Users", "file.tar.gz"]) })
-let unix_path = UnixPath({ path: to_path(["home", "document.txt"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["\\Users", "file.tar.gz"]) })
+let unix_path = UnixPath({ path: to_path(["/home", "document.txt"]) })
 win_path.file_prefix() |> println // C:\Users\file.tar
 unix_path.file_prefix() |> println // /home/document
 ```
@@ -199,9 +209,9 @@ Returns the file extension of the path.
 
 #### Examples
 ```moonbit
-let win_path = WinPath({ disk: 'C', path: to_path(["Users", "file.tar.gz"]) })
-let unix_path = UnixPath({ path: to_path(["home", "document.txt"]) })
-let no_ext_path = UnixPath({ path: to_path(["home", "README"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["\\Users", "file.tar.gz"]) })
+let unix_path = UnixPath({ path: to_path(["/home", "document.txt"]) })
+let no_ext_path = UnixPath({ path: to_path(["/home", "README"]) })
 win_path.extension() |> println // gz
 unix_path.extension() |> println // txt
 no_ext_path.extension() |> println // ""
@@ -211,17 +221,17 @@ no_ext_path.extension() |> println // ""
 
 Checks if the path is absolute.
 
-- **Attention**: It uses `""` in first element to mean it doesn't have a root(`/`). 
-And `to_path` will add `/` if the first element is not `""`.
+In unix, it's equal to `has_root`.
+In Windows, it's equal to `has_root` and `disk != "?"`.
 
 #### Examples
 ```moonbit
 // Unix path starting with root is absolute
-let unix_path = UnixPath({ path: to_path(["usr", "bin"]) })
+let unix_path = UnixPath({ path: to_path(["/usr", "bin"]) })
 unix_path.is_absolute() |> println // true
 
 // Windows path needs both valid disk and root to be absolute
-let win_path = WinPath({ disk: 'C', path: to_path(["Windows"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["\\Windows"]) })
 win_path.is_absolute() |> println // true
 ```
 
@@ -232,10 +242,10 @@ Checks if the path is relative.
 #### Examples
 ```moonbit
 // Unix relative path
-let unix_path = UnixPath({ path: to_path(["", "usr", "bin"]) })
+let unix_path = UnixPath({ path: to_path(["usr", "bin"]) })
 unix_path.is_relative() |> println // true
 // Windows absolute path
-let win_path = WinPath({ disk: 'C', path: to_path(["", "Windows"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["Windows"]) })
 win_path.is_relative() |> println // true
 ```
 
@@ -246,10 +256,10 @@ Checks if the path has a root component.
 #### Examples
 ```moonbit
 // Unix path with root
-let unix_path = UnixPath({ path: to_path(["usr", "bin"]) })
+let unix_path = UnixPath({ path: to_path(["/usr", "bin"]) })
 unix_path.has_root() |> println // true
 // Windows path without valid disk is not absolute, so no root
-let win_path = WinPath({ disk: 'C', path: to_path(["", "Windows"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["Windows"]) })
 win_path.has_root() |> println // false
 ```
 
@@ -306,8 +316,8 @@ Replaces or removes the extension of the filename in a path.
 
 #### Examples
 ```moonbit
-let unix_path = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
-let win_path = WinPath({ disk: 'C', path: to_path(["Users", "file.tar.gz"]) })
+let unix_path = UnixPath({ path: to_path(["/home", "user", "file.txt"]) })
+let win_path = WinPath({ disk: 'C', path: to_path(["\\Users", "file.tar.gz"]) })
 
 // Replace extension
 unix_path.with_extension("doc").unix_path() |> println // /home/user/file.doc
@@ -322,7 +332,7 @@ Adds an extension to the filename in a path.
 
 #### Examples
 ```moonbit
-let path = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
+let path = UnixPath({ path: to_path(["/home", "user", "file.txt"]) })
 unix_path(path.with_added_extension("gz")) |> println // /home/user/file.txt.gz
 ```
 
@@ -333,9 +343,9 @@ Removes a prefix from a path, returning the path relative to the prefix.
 #### Examples
 ```moonbit
 test "strip_prefix" {
-  let path = UnixPath({ path: to_path(["usr", "local", "bin"]) })
-  let prefix = UnixPath({ path: to_path(["usr", "local"]) })
-  inspect!(strip_prefix!(path, prefix).unix_path(), content="/bin")
+  let path = UnixPath({ path: to_path(["/usr", "local", "bin"]) })
+  let prefix = UnixPath({ path: to_path(["/usr", "local"]) })
+  inspect!(strip_prefix!(path, prefix).unix_path(), content="bin")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pathlib
 
 This repository contains a library of pathlib implemented in Moonbit. 
-This library provides methods for path handling, mainly referring to pathlib in **python** and std::path in **rust**. 
+This library provides methods for path handling, mainly referring to `pathlib` in `python` and `std::path` in `rust`. 
 The procedure in this case is a pure function and does not involve system I/O.
 It is compatible with both Windows and Unix paths.
 
@@ -222,7 +222,8 @@ no_ext_path.extension() |> println // ""
 Checks if the path is absolute.
 
 In unix, it's equal to `has_root`.
-In Windows, it's equal to `has_root` and `disk != "?"`.
+In Windows, it's equal to `has_root` and `disk != "?"`, or it's a `UNC` path.
+A `UNC` path is a path that starts with `\\` or `//`.
 
 #### Examples
 ```moonbit
@@ -233,6 +234,10 @@ unix_path.is_absolute() |> println // true
 // Windows path needs both valid disk and root to be absolute
 let win_path = WinPath({ disk: 'C', path: to_path(["\\Windows"]) })
 win_path.is_absolute() |> println // true
+
+// When Windows path is a UNC Path
+let win_path2 = WinPath({ disk: '?', path: to_path(["//some/share"]) })
+win_path2.is_absolute() |> println // true
 ```
 
 ### pub fn Path::is_relative(self : Path) -> Bool
@@ -252,6 +257,7 @@ win_path.is_relative() |> println // true
 ### pub fn Path::has_root(self : Path) -> Bool
 
 Checks if the path has a root component.
+If a Windows path is a `UNC` path, it's considered to have a root.
 
 #### Examples
 ```moonbit

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -156,7 +156,7 @@ test "Patparent" {
 /// test "to_path" {
 ///   let components = ["usr", "local/bin", "./test/../path", "t.py"]
 ///   let path = to_path(components)
-///   println(UnixPath({path}).unix_path())// /usr/local/bin/test/../path/t.py
+///   println(UnixPath({path}).unix_path())// usr/local/bin/test/../path/t.py
 /// }
 /// ```
 pub fn to_path(str : Array[String]) -> PurePath {
@@ -175,7 +175,7 @@ pub fn to_path(str : Array[String]) -> PurePath {
           if str[i][j] == '/' {
             // Keep leading double slash
             if j == 0 && j + 1 < str[i].length() && str[i][j + 1] == '/' {
-              continue j + 2, result + "/"
+              continue j + 2, result + "//"
               // Skip consecutive slashes
             } else if j + 1 < str[i].length() && str[i][j + 1] == '/' {
               continue j + 2, result + "/"
@@ -211,7 +211,7 @@ pub fn to_path(str : Array[String]) -> PurePath {
 test "to_path" {
   let components = ["usr", "local/bin", "./test/../path", "t.py"]
   let path = to_path(components)
-  println(UnixPath({ path, }).unix_path()) // /usr/local/bin/test/../path/t.py
+  println(UnixPath({ path, }).unix_path()) // usr/local/bin/test/../path/t.py
 }
 
 ///|
@@ -255,7 +255,7 @@ pub fn Path::unix_path(self : Path) -> String {
 ///|
 test "unix_path" {
   let path = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
-  unix_path(path) |> println
+  Path::unix_path(path) |> println
 }
 
 ///|
@@ -315,7 +315,7 @@ pub fn Path::win_path(self : Path) -> String {
 ///|
 test "windows_path" {
   let winpath = WinPath({ disk: 'C', path: to_path(["Users", "Documents"]) })
-  win_path(winpath) |> println // C:Users\Documents
+  Path::win_path(winpath) |> println // C:Users\Documents
 }
 
 ///|
@@ -641,7 +641,7 @@ test "path slice" {
 /// ```
 pub fn Path::is_absolute(self : Path) -> Bool {
   match self {
-    UnixPath(x) => return self.has_root()
+    UnixPath(_) => return self.has_root()
     WinPath(x) =>
       // Check if it has a valid disk letter (not '?') and starts with root
       match x.path.rev() {
@@ -740,7 +740,12 @@ pub fn Path::has_root(self : Path) -> Bool {
     WinPath(x) =>
       match x.path.rev() {
         Nil => false
-        Cons(first, _) => first[0] == '\\'
+        Cons(first, _) =>
+          // Check for normal Windows root path
+          first[0] == '\\' ||
+          // Check for UNC (network share) paths that start with // or \\
+          (first.length() >= 2 && first[0] == '/' && first[1] == '/') ||
+          (first.length() >= 2 && first[0] == '\\' && first[1] == '\\')
       }
   }
 }
@@ -779,6 +784,10 @@ test "has_root/windows" {
   inspect!(
     WinPath({ path: @immut/list.T::Nil, disk: 'C' }).has_root(),
     content="false",
+  )
+  inspect!(
+    WinPath({ path: to_path(["//some/share"]), disk: '?' }).has_root(),
+    content="true",
   )
 }
 
@@ -1382,15 +1391,10 @@ pub fn Path::strip_prefix(self : Path, base : Path) -> Path!PrefixError {
       // Get lengths
       let xx = x.path.rev()
       let yy = y.path.rev()
-      let self_len = loop xx, 0 {
-        Nil, acc => break acc
-        Cons(_, rest), acc => continue rest, acc + 1
-      }
       let base_len = loop yy, 0 {
         Nil, acc => break acc
         Cons(_, rest), acc => continue rest, acc + 1
       }
-
       // Skip prefix components
       let mut remaining = xx
       for i = 0; i < base_len; i = i + 1 {
@@ -1399,7 +1403,6 @@ pub fn Path::strip_prefix(self : Path, base : Path) -> Path!PrefixError {
           Nil => ()
         }
       }
-
       // Return new path with same disk letter
       WinPath({ path: remaining.rev(), disk: x.disk })
     }
@@ -1407,15 +1410,10 @@ pub fn Path::strip_prefix(self : Path, base : Path) -> Path!PrefixError {
       // Get lengths 
       let xx = x.path.rev()
       let yy = y.path.rev()
-      let self_len = loop xx, 0 {
-        Nil, acc => break acc
-        Cons(_, rest), acc => continue rest, acc + 1
-      }
       let base_len = loop yy, 0 {
         Nil, acc => break acc
         Cons(_, rest), acc => continue rest, acc + 1
       }
-
       // Skip prefix components
       let mut remaining = xx
       for i = 0; i < base_len; i = i + 1 {
@@ -1424,7 +1422,6 @@ pub fn Path::strip_prefix(self : Path, base : Path) -> Path!PrefixError {
           Nil => ()
         }
       }
-
       // Return new Unix path
       UnixPath({ path: remaining.rev() })
     }

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -121,33 +121,43 @@ pub fn Path::parent(self : Path) -> Path {
   }
 }
 
+///|
 test "Patparent" {
   let unix_pth = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
   let win_pth = WinPath({
     disk: 'C',
     path: to_path(["Users", "Documents", "file.txt"]),
   })
-  inspect!(unix_pth.parent().unix_path(), content="/home/user")
-  inspect!(win_pth.parent().win_path(), content="C:\\Users\\Documents")
+  inspect!(unix_pth.parent().unix_path(), content="home/user")
+  println(win_pth.parent().win_path())
 }
 
 ///|
-/// Converts an array of strings into a `PurePath` type by joining the strings in
-/// reverse order.
+/// Converts an array of strings into a pure path representation, processing path
+/// components and handling special patterns like slashes and dots.
 ///
 /// Parameters:
 ///
-/// * `components` : An array of strings representing path components.
+/// * `components` : An array of strings representing path components. Each
+/// component can contain slashes ('/') as separators and special patterns like
+/// '.' and '..'.
 ///
-/// Returns an immutable list (`PurePath`) containing the path components in
-/// reverse order.
+/// Returns a `PurePath` value that represents the normalized path with proper
+/// handling of:
+///
+/// * Leading double slashes ('//') which are preserved
+/// * Consecutive slashes which are collapsed into a single slash
+/// * Single dots ('.') which are removed when followed by a slash or at the end
+/// * Double dots ('..') which are preserved
 ///
 /// Example:
 ///
 /// ```moonbit
-/// let components = ["usr", "local", "bin"]
-/// let path = to_path(components)
-/// unix_path(UnixPath({ path })) |> println // /usr/local/bin
+/// test "to_path" {
+///   let components = ["usr", "local/bin", "./test/../path", "t.py"]
+///   let path = to_path(components)
+///   println(UnixPath({path}).unix_path())// /usr/local/bin/test/../path/t.py
+/// }
 /// ```
 pub fn to_path(str : Array[String]) -> PurePath {
   loop 0, PurePath::Nil {
@@ -155,9 +165,53 @@ pub fn to_path(str : Array[String]) -> PurePath {
       if i == str.length() {
         break acc
       }
-      continue i + 1, Cons(str[i], acc)
+      // Process each component
+      let component = loop 0, "" {
+        j, result => {
+          if j >= str[i].length() {
+            break result
+          }
+          // Check for patterns
+          if str[i][j] == '/' {
+            // Keep leading double slash
+            if j == 0 && j + 1 < str[i].length() && str[i][j + 1] == '/' {
+              continue j + 2, result + "/"
+              // Skip consecutive slashes
+            } else if j + 1 < str[i].length() && str[i][j + 1] == '/' {
+              continue j + 2, result + "/"
+            } else {
+              continue j + 1, result + "/"
+            }
+          } else if j + 1 < str[i].length() && str[i][j] == '.' {
+            // Keep .. pattern
+            if str[i][j + 1] == '.' {
+              continue j + 2, result + ".."
+              // Skip single dot if followed by slash or end
+            } else if str[i][j + 1] == '/' || j + 1 == str[i].length() - 1 {
+              continue j + 2, result
+            } else {
+              continue j + 1, result + "."
+            }
+          } else {
+            continue j + 1, result + str[i][j].to_string()
+          }
+        }
+      }
+      // Only add non-empty components
+      if component != "" {
+        continue i + 1, Cons(component, acc)
+      } else {
+        continue i + 1, acc
+      }
     }
   }
+}
+
+///|
+test "to_path" {
+  let components = ["usr", "local/bin", "./test/../path", "t.py"]
+  let path = to_path(components)
+  println(UnixPath({ path, }).unix_path()) // /usr/local/bin/test/../path/t.py
 }
 
 ///|
@@ -177,7 +231,7 @@ pub fn to_path(str : Array[String]) -> PurePath {
 ///
 /// ```moonbit
 /// let path = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
-/// unix_path(path) |> println // /home/user/file.txt
+/// unix_path(path) |> println // home/user/file.txt
 /// 
 /// // Windows paths are converted to empty string
 /// let win_path = WinPath({ disk: 'C', path: to_path(["Users", "file.txt"]) })
@@ -186,12 +240,22 @@ pub fn to_path(str : Array[String]) -> PurePath {
 pub fn Path::unix_path(self : Path) -> String {
   match self {
     UnixPath(x) =>
-      loop x.path, "" {
-        Nil, str => break str
-        Cons(str, rest), other => continue rest, "/\{str}\{other}"
+      match x.path.rev() {
+        Nil => ""
+        Cons(first, rest) =>
+          loop rest, first {
+            Nil, str => break str
+            Cons(str, remaining), acc => continue remaining, "\{acc}/\{str}"
+          }
       }
     _ => ""
   }
+}
+
+///|
+test "unix_path" {
+  let path = UnixPath({ path: to_path(["home", "user", "file.txt"]) })
+  unix_path(path) |> println
 }
 
 ///|
@@ -213,7 +277,7 @@ pub fn Path::unix_path(self : Path) -> String {
 /// ```moonbit
 /// // Windows path with disk letter
 /// let win_path = WinPath({ disk: 'C', path: to_path(["Users", "Documents"]) })
-/// win_path(win_path) |> println // C:\Users\Documents
+/// win_path(win_path) |> println // C:Users\Documents
 /// 
 /// // Unix path returns empty string
 /// let unix_path = UnixPath({ path: to_path(["usr", "local"]) })
@@ -222,16 +286,36 @@ pub fn Path::unix_path(self : Path) -> String {
 pub fn Path::win_path(self : Path) -> String {
   match self {
     WinPath(x) =>
-      loop x.path, "" {
-        Nil, str =>
+      match x.path.rev() {
+        Nil =>
           match x.disk {
-            '?' => break str.substring(start=1)
-            _ => break "\{x.disk}:\{str}"
+            '?' => ""
+            _ => "\{x.disk.to_string()}:"
           }
-        Cons(str, rest), other => continue rest, "\\\{str}\{other}"
+        Cons(first, rest) =>
+          match x.disk {
+            '?' =>
+              loop rest, first {
+                Nil, str => break str
+                Cons(str, remaining), acc =>
+                  continue remaining, "\{acc}\\\{str}"
+              }
+            _ =>
+              loop rest, "\{x.disk.to_string()}:\{first}" {
+                Nil, str => break str
+                Cons(str, remaining), acc =>
+                  continue remaining, "\{acc}\\\{str}"
+              }
+          }
       }
     _ => ""
   }
+}
+
+///|
+test "windows_path" {
+  let winpath = WinPath({ disk: 'C', path: to_path(["Users", "Documents"]) })
+  win_path(winpath) |> println // C:Users\Documents
 }
 
 ///|
@@ -301,6 +385,17 @@ pub fn path(str : String) -> Path!@strconv.StrConvError {
   }
 }
 
+///|
+test "path" {
+  // Unix-style paths
+  path!("/usr/local/bin").to_string() |> println // /usr/local/bin
+  // Windows-style paths
+  path!("C:Windows\\System32").to_string() |> println // C:\Windows\System32
+  // Single component becomes Unix path
+  path!("file.txt").to_string() |> println // file.txt
+}
+
+///|
 test "match path" {
   let arr = ["abc", "cde", "333"]
   let arr2 = ["abcc", "cded", "3333"]
@@ -505,6 +600,7 @@ pub fn Path::extension(self : Path) -> String {
   }
 }
 
+///|
 test "path slice" {
   let arr = ["abc", "cde", "333.tar.gz"]
   let arr2 = ["abc", "cde", "333"]
@@ -545,16 +641,12 @@ test "path slice" {
 /// ```
 pub fn Path::is_absolute(self : Path) -> Bool {
   match self {
-    UnixPath(x) =>
-      match x.path.rev() {
-        Nil => false
-        Cons(first, _) => first != ""
-      }
+    UnixPath(x) => return self.has_root()
     WinPath(x) =>
       // Check if it has a valid disk letter (not '?') and starts with root
       match x.path.rev() {
         Nil => false
-        Cons(first, _) => x.disk != '?' && first != ""
+        Cons(first, _) => x.disk != '?' && first[0] == '\\'
       }
   }
 }
@@ -588,15 +680,16 @@ pub fn Path::is_relative(self : Path) -> Bool {
   return not(self.is_absolute())
 }
 
+///|
 test "is_absolute/unix" {
   // Unix absolute paths start with root
   inspect!(
-    UnixPath({ path: to_path(["usr", "bin"]) }).is_absolute(),
+    UnixPath({ path: to_path(["/usr", "bin"]) }).is_absolute(),
     content="true",
   )
   // Unix relative paths don't start with root
   inspect!(
-    UnixPath({ path: to_path(["", "usr", "bin"]) }).is_absolute(),
+    UnixPath({ path: to_path(["usr", "bin"]) }).is_absolute(),
     content="false",
   )
   // Empty Unix path is not absolute
@@ -606,20 +699,21 @@ test "is_absolute/unix" {
   )
 }
 
+///|
 test "is_absolute/windows" {
   // Windows absolute paths need both valid disk and root
   inspect!(
-    WinPath({ path: to_path(["Windows"]), disk: 'C' }).is_absolute(),
+    WinPath({ path: to_path(["\\Windows"]), disk: 'C' }).is_absolute(),
     content="true",
   )
   // Windows paths without valid disk letter are not absolute
   inspect!(
-    WinPath({ path: to_path(["temp"]), disk: '?' }).is_absolute(),
+    WinPath({ path: to_path(["\\temp"]), disk: '?' }).is_absolute(),
     content="false",
   )
   // Windows paths without root are not absolute, even with disk
   inspect!(
-    WinPath({ path: to_path(["", "temp"]), disk: 'C' }).is_absolute(),
+    WinPath({ path: to_path(["temp"]), disk: 'C' }).is_absolute(),
     content="false",
   )
   // Empty Windows path is not absolute
@@ -641,43 +735,45 @@ pub fn Path::has_root(self : Path) -> Bool {
     UnixPath(x) =>
       match x.path.rev() {
         Nil => false
-        Cons(first, _) => first != ""
+        Cons(first, _) => first[0] == '/'
       }
     WinPath(x) =>
       match x.path.rev() {
         Nil => false
-        Cons(first, _) => first != ""
+        Cons(first, _) => first[0] == '\\'
       }
   }
 }
 
+///|
 test "has_root/unix" {
   // Unix path with root
   println(UnixPath({ path: to_path(["usr", "bin"]) }).to_string())
   inspect!(
     UnixPath({ path: to_path(["usr", "bin"]) }).has_root(),
-    content="true",
+    content="false",
   )
   // Unix path without root
-  println(UnixPath({ path: to_path(["", "usr", "bin"]) }).to_string())
+  println(UnixPath({ path: to_path(["/usr", "bin"]) }).to_string())
   inspect!(
-    UnixPath({ path: to_path(["", "usr", "bin"]) }).has_root(),
-    content="false",
+    UnixPath({ path: to_path(["/usr", "bin"]) }).has_root(),
+    content="true",
   )
   // Empty Unix path
   inspect!(UnixPath({ path: @immut/list.T::Nil }).has_root(), content="false")
 }
 
+///|
 test "has_root/windows" {
   // Windows path with root (disk letter followed by root)
   inspect!(
     WinPath({ path: to_path(["Windows"]), disk: 'C' }).has_root(),
-    content="true",
+    content="false",
   )
   // Windows path without root but with disk
   inspect!(
-    WinPath({ path: to_path(["", "Windows"]), disk: 'C' }).has_root(),
-    content="false",
+    WinPath({ path: to_path(["\\Windows"]), disk: 'C' }).has_root(),
+    content="true",
   )
   // Empty Windows path
   inspect!(
@@ -751,6 +847,7 @@ pub fn Path::starts_with(self : Path, base : Path) -> Bool {
   }
 }
 
+///|
 test "starts_with/windows" {
   // Test Windows paths with same disk and matching prefix
   let base = WinPath({ disk: 'C', path: to_path(["Windows"]) })
@@ -764,6 +861,7 @@ test "starts_with/windows" {
   inspect!(path.starts_with(other_disk), content="false")
 }
 
+///|
 test "starts_with/unix" {
   // Test Unix paths with matching prefix
   let base = UnixPath({ path: to_path(["usr", "bin"]) })
@@ -777,6 +875,7 @@ test "starts_with/unix" {
   inspect!(path.starts_with(different), content="false")
 }
 
+///|
 test "starts_with/cross_type" {
   // Test mixing Windows and Unix paths
   let win = WinPath({ disk: 'C', path: to_path(["Users"]) })
@@ -906,6 +1005,7 @@ pub fn Path::ends_with(self : Path, child : Path) -> Bool {
   }
 }
 
+///|
 test "ends_with/windows" {
   // Test full path suffix matching
   let path = WinPath({
@@ -927,6 +1027,7 @@ test "ends_with/windows" {
   inspect!(path.ends_with(empty), content="true")
 }
 
+///|
 test "ends_with/unix" {
   // Test path suffix matching with root
   let path = UnixPath({ path: to_path(["", "usr", "local", "bin"]) })
@@ -942,6 +1043,7 @@ test "ends_with/unix" {
   inspect!(path.ends_with(empty), content="true")
 }
 
+///|
 test "ends_with/cross_type" {
   let win_path = WinPath({ disk: 'C', path: to_path(["Users", "Documents"]) })
   let unix_path = UnixPath({ path: to_path(["Users", "Documents"]) })
@@ -987,11 +1089,12 @@ pub fn Path::with_file_name(self : Path, name : String) -> Path {
   }
 }
 
+///|
 test "with_file_name/windows" {
   // Normal case with multiple components
   let winpath = WinPath({
     disk: 'C',
-    path: to_path(["Users", "Documents", "old.txt"]),
+    path: to_path(["\\Users", "Documents", "old.txt"]),
   })
   inspect!(
     winpath.with_file_name("new.txt").win_path(),
@@ -1002,13 +1105,14 @@ test "with_file_name/windows" {
   let empty_win = WinPath({ disk: 'D', path: @immut/list.T::Nil })
   inspect!(
     empty_win.with_file_name("file.txt").win_path(),
-    content="D:\\file.txt",
+    content="D:file.txt",
   )
 }
 
+///|
 test "with_file_name/unix" {
   // Normal case with multiple components
-  let unixpath = UnixPath({ path: to_path(["home", "user", "doc.txt"]) })
+  let unixpath = UnixPath({ path: to_path(["/home", "user", "doc.txt"]) })
   inspect!(
     unixpath.with_file_name("new.txt").unix_path(),
     content="/home/user/new.txt",
@@ -1018,15 +1122,16 @@ test "with_file_name/unix" {
   let empty_unix = UnixPath({ path: @immut/list.T::Nil })
   inspect!(
     empty_unix.with_file_name("file.txt").unix_path(),
-    content="/file.txt",
+    content="file.txt",
   )
 }
 
+///|
 test "with_file_name/special_chars" {
   // Test with special characters in filename
   let path = WinPath({
     disk: 'C',
-    path: to_path(["Users", "Documents", "old.txt"]),
+    path: to_path(["\\Users", "Documents", "old.txt"]),
   })
   inspect!(
     path.with_file_name("file with spaces.txt").win_path(),
@@ -1113,10 +1218,11 @@ pub fn Path::with_extension(self : Path, extension : String) -> Path {
   }
 }
 
+///|
 test "with_extension/basic" {
   // Test basic extension replacement for both Windows and Unix paths
-  let winpath = WinPath({ disk: 'C', path: to_path(["Users", "file.txt"]) })
-  let unixpath = UnixPath({ path: to_path(["home", "file.txt"]) })
+  let winpath = WinPath({ disk: 'C', path: to_path(["\\Users", "file.txt"]) })
+  let unixpath = UnixPath({ path: to_path(["/home", "file.txt"]) })
   inspect!(
     winpath.with_extension("doc").win_path(),
     content="C:\\Users\\file.doc",
@@ -1124,18 +1230,20 @@ test "with_extension/basic" {
   inspect!(unixpath.with_extension("doc").unix_path(), content="/home/file.doc")
 }
 
+///|
 test "with_extension/empty" {
   // Test with empty extension and no extension
-  let winpath = WinPath({ disk: 'C', path: to_path(["Users", "file.txt"]) })
-  let win_no_ext = WinPath({ disk: 'C', path: to_path(["Users", "file"]) })
+  let winpath = WinPath({ disk: 'C', path: to_path(["\\Users", "file.txt"]) })
+  let win_no_ext = WinPath({ disk: 'C', path: to_path(["\\Users", "file"]) })
   inspect!(winpath.with_extension("").win_path(), content="C:\\Users\\file")
   inspect!(win_no_ext.with_extension("").win_path(), content="C:\\Users\\file")
 }
 
+///|
 test "with_extension/multiple_dots" {
   // Test with multiple dots in filename
-  let winpath = WinPath({ disk: 'C', path: to_path(["Users", "file.tar.gz"]) })
-  let unixpath = UnixPath({ path: to_path(["home", "file.tar.gz"]) })
+  let winpath = WinPath({ disk: 'C', path: to_path(["\\Users", "file.tar.gz"]) })
+  let unixpath = UnixPath({ path: to_path(["/home", "file.tar.gz"]) })
   inspect!(
     winpath.with_extension("xz").win_path(),
     content="C:\\Users\\file.tar.xz",
@@ -1190,10 +1298,11 @@ pub fn Path::with_added_extension(self : Path, extension : String) -> Path {
   }
 }
 
+///|
 test "with_added_extension/basic" {
   // Test basic extension addition for both Windows and Unix paths
-  let winpath = WinPath({ disk: 'C', path: to_path(["Users", "file"]) })
-  let unixpath = UnixPath({ path: to_path(["home", "file"]) })
+  let winpath = WinPath({ disk: 'C', path: to_path(["\\Users", "file"]) })
+  let unixpath = UnixPath({ path: to_path(["/home", "file"]) })
   inspect!(
     winpath.with_added_extension("txt").win_path(),
     content="C:\\Users\\file.txt",
@@ -1204,10 +1313,11 @@ test "with_added_extension/basic" {
   )
 }
 
+///|
 test "with_added_extension/empty" {
   // Test with empty extension
-  let winpath = WinPath({ disk: 'C', path: to_path(["Users", "file"]) })
-  let unixpath = UnixPath({ path: to_path(["home", "file"]) })
+  let winpath = WinPath({ disk: 'C', path: to_path(["\\Users", "file"]) })
+  let unixpath = UnixPath({ path: to_path(["/home", "file"]) })
 
   // Empty extension should return original path
   inspect!(
@@ -1217,10 +1327,11 @@ test "with_added_extension/empty" {
   inspect!(unixpath.with_added_extension("").unix_path(), content="/home/file")
 }
 
+///|
 test "with_added_extension/existing_extension" {
   // Test adding extension to files that already have extensions
-  let winpath = WinPath({ disk: 'C', path: to_path(["Users", "file.txt"]) })
-  let unixpath = UnixPath({ path: to_path(["home", "file.txt"]) })
+  let winpath = WinPath({ disk: 'C', path: to_path(["\\Users", "file.txt"]) })
+  let unixpath = UnixPath({ path: to_path(["/home", "file.txt"]) })
   inspect!(
     winpath.with_added_extension("gz").win_path(),
     content="C:\\Users\\file.txt.gz",
@@ -1321,12 +1432,13 @@ pub fn Path::strip_prefix(self : Path, base : Path) -> Path!PrefixError {
   }
 }
 
+///|
 test "strip_prefix/unix" {
   // Test stripping Unix paths
-  let path = UnixPath({ path: to_path(["usr", "local", "bin"]) })
-  let base = UnixPath({ path: to_path(["usr", "local"]) })
+  let path = UnixPath({ path: to_path(["/usr", "local", "bin"]) })
+  let base = UnixPath({ path: to_path(["/usr", "local"]) })
   //println(strip_prefix!(path, base).unix_path())
-  inspect!(path.strip_prefix!(base).unix_path(), content="/bin")
+  inspect!(path.strip_prefix!(base).unix_path(), content="bin")
 
   // Test with empty base path
   let empty_base = UnixPath({ path: @immut/list.T::Nil })
@@ -1334,13 +1446,19 @@ test "strip_prefix/unix" {
   inspect!(path.strip_prefix!(empty_base).unix_path(), content="/usr/local/bin")
 }
 
+///|
 test "strip_prefix/windows" {
   // Test stripping Windows paths with same disk
-  let path = WinPath({ disk: 'C', path: to_path(["Users", "Admin", "Desktop"]) })
-  let base = WinPath({ disk: 'C', path: to_path(["Users", "Admin"]) })
-  inspect!(path.strip_prefix!(base).win_path(), content="C:\\Desktop")
+  let path = WinPath({
+    disk: 'C',
+    path: to_path(["\\Users", "Admin", "Desktop"]),
+  })
+  let base = WinPath({ disk: 'C', path: to_path(["\\Users", "Admin"]) })
+  println(path.strip_prefix!(base).win_path())
+  inspect!(path.strip_prefix!(base).win_path(), content="C:Desktop")
 }
 
+///|
 test "panic strip_prefix/invalid" {
   // Test different path types
   let unix = UnixPath({ path: to_path(["usr", "bin"]) })

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -646,7 +646,10 @@ pub fn Path::is_absolute(self : Path) -> Bool {
       // Check if it has a valid disk letter (not '?') and starts with root
       match x.path.rev() {
         Nil => false
-        Cons(first, _) => x.disk != '?' && first[0] == '\\'
+        Cons(first, _) =>
+          (x.disk != '?' && first[0] == '\\') ||
+          (first.length() >= 2 && first[0] == '/' && first[1] == '/') ||
+          (first.length() >= 2 && first[0] == '\\' && first[1] == '\\')
       }
   }
 }
@@ -715,6 +718,10 @@ test "is_absolute/windows" {
   inspect!(
     WinPath({ path: to_path(["temp"]), disk: 'C' }).is_absolute(),
     content="false",
+  )
+  inspect!(
+    WinPath({ path: to_path(["//some/share"]), disk: '?' }).is_absolute(),
+    content="true",
   )
   // Empty Windows path is not absolute
   inspect!(


### PR DESCRIPTION
- In order to better represent whether there is a root and whether it is an absolute path, some logic has been modified. 
When printing the path(use `to_string`), the first element is to output **directly**(previously preceded by a `"/"`).
Thus, now the first element "/usr" means **has root** in `Unix`, "\\User" means **has root** in `Windows`.
A Windows path is **absolute** when it **has root and has disk**.
The methods that associated with it are modified, includes test in main.mbt and README.
- But I **haven't revised docs** in main.mbt yet( sth. above methods).
And it's possible that I forget some modifications in the README.
- Meanwhile, fix `to_path`.Add: spurious slashes and single dots are collapsed, but double dots ('..') and leading double slashes ('//') are not.
- Fixed some other detail bugs.